### PR TITLE
make sure master IP is stripped of whitespace

### DIFF
--- a/bin/gce-10acre-ranch
+++ b/bin/gce-10acre-ranch
@@ -193,7 +193,7 @@ delete_nodes()
 get_master_ip()
 {
     IP=$(gcloud compute instances describe "${MASTER_NAME}" --project ${GCE_PROJECT} --zone ${ZONE} | grep natIP | cut -d':' -f2)
-    echo $IP
+    echo ${IP%%[[:space:]]}
 }
 
 get_os_project()


### PR DESCRIPTION
Was embedded an \r char in some instances which then caused /ping to fail.